### PR TITLE
[FEAT] Add router-agnostic OpenAPI toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Local agent instructions
+AGENTS.md
+.codex

--- a/README.md
+++ b/README.md
@@ -175,6 +175,71 @@ func main() {
 
 In this example, the `handler` function creates a standard success response with a status code of 200 and some content. It then writes this response to the HTTP response writer. This ensures that all responses follow the same structure and include the necessary metadata.
 
+## Router-agnostic OpenAPI documentation
+
+The package includes a router-agnostic registration layer for OpenAPI 3 and Swagger UI. The native adapter uses only Go's standard `net/http` package, while adapters for Gin, Echo, chi, gorilla/mux, or other routers should live in the application that chooses those routers.
+
+The philosophy is to keep `github.com/jgolang/api` small and predictable: prefer Go's standard library and `github.com/jgolang/...` dependencies, with any exception made explicitly.
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/jgolang/api"
+	"github.com/jgolang/api/stdadapter"
+)
+
+type CreateTaskRequest struct {
+	Title string `json:"title"`
+}
+
+type TaskResponse struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+}
+
+func createTask(w http.ResponseWriter, r *http.Request) {
+	api.Success201().Write(w, r)
+}
+
+func listTasks(w http.ResponseWriter, r *http.Request) {
+	api.Success200().Write(w, r)
+}
+
+func main() {
+	registry := api.NewRegistry(api.Info{
+		Title:   "Tasks API",
+		Version: "1.0.0",
+	})
+	registry.AddSecurityScheme("bearerAuth", api.BearerSecurity("JWT"))
+
+	router := stdadapter.New(http.NewServeMux(), registry)
+
+	api.Post(router, "/tasks", createTask,
+		api.Summary("Create task"),
+		api.Tags("tasks"),
+		api.Body(CreateTaskRequest{}),
+		api.Security("bearerAuth"),
+		api.Status(201, TaskResponse{}),
+	)
+
+	api.Get(router, "/tasks", listTasks,
+		api.Summary("List tasks"),
+		api.Tags("tasks"),
+		api.Status(200, []TaskResponse{}),
+	)
+
+	router.Handle("GET", "/openapi.json", api.OpenAPIHandler(registry))
+	router.Handle("GET", "/docs", api.SwaggerUIHandler("/openapi.json"))
+
+	http.ListenAndServe(":8080", router)
+}
+```
+
+See [docs/openapi.md](docs/openapi.md) for security schemes, schema tags, response aliases, and external adapter examples.
+
 ## Contributing
 
 If you have suggestions for how We could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,0 +1,132 @@
+# Router-agnostic OpenAPI documentation
+
+The package includes a small router-agnostic registration layer. Adapters implement the `api.Router` interface and store route metadata in an `api.Registry`, which can generate an OpenAPI 3 document and Swagger UI.
+
+This module intentionally avoids importing third-party routers. The native adapter uses only Go's standard `net/http` package. If an application uses Gin, Echo, chi, gorilla/mux, or another router, create the adapter in that application or in a separate module owned by the implementer. The philosophy is to keep `github.com/jgolang/api` small, predictable, and free of router-specific dependencies.
+
+In general, dependencies should come from Go's standard library or from `github.com/jgolang/...`. Exceptions should be explicit and intentional.
+
+## Example
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/jgolang/api"
+	"github.com/jgolang/api/stdadapter"
+)
+
+type CreateTaskRequest struct {
+	Title string `json:"title"`
+}
+
+type TaskResponse struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+}
+
+func createTask(w http.ResponseWriter, r *http.Request) {
+	api.Success201().Write(w, r)
+}
+
+func listTasks(w http.ResponseWriter, r *http.Request) {
+	api.Success200().Write(w, r)
+}
+
+func main() {
+	registry := api.NewRegistry(api.Info{
+		Title:   "Tasks API",
+		Version: "1.0.0",
+	})
+	registry.AddSecurityScheme("bearerAuth", api.BearerSecurity("JWT"))
+
+	router := stdadapter.New(http.NewServeMux(), registry)
+
+	api.Post(router, "/tasks", createTask,
+		api.Summary("Create task"),
+		api.Tags("tasks"),
+		api.Body(CreateTaskRequest{}),
+		api.Security("bearerAuth"),
+		api.Status(201, TaskResponse{}),
+	)
+
+	api.Get(router, "/tasks", listTasks,
+		api.Summary("List tasks"),
+		api.Tags("tasks"),
+		api.Status(200, []TaskResponse{}),
+	)
+
+	router.Handle("GET", "/openapi.json", api.OpenAPIHandler(registry))
+	router.Handle("GET", "/docs", api.SwaggerUIHandler("/openapi.json"))
+
+	http.ListenAndServe(":8080", router)
+}
+```
+
+`api.Status`, `api.Responds`, and `api.ResponseStatus` document responses. The longer `ResponseStatus` name is kept because this package already has an exported `api.Response` interface.
+
+## Route metadata options
+
+- `api.Summary("Create task")`
+- `api.Description("Creates a new task")`
+- `api.Tags("tasks")`
+- `api.Body(CreateTaskRequest{})`
+- `api.BodySchema(&api.Schema{Type: "object"})`
+- `api.Status(200, TaskResponse{})`
+- `api.ResponseStatus(200, TaskResponse{})`
+- `api.ResponseSchema(400, "Bad Request", &api.Schema{Type: "object"})`
+- `api.Query("page", api.Int, false)`
+- `api.Path("id", api.Int, true)`
+- `api.Security("bearerAuth")`
+
+## Security schemes
+
+Security requirements are declared per route with `api.Security("name")`. Reusable schemes are registered in the registry:
+
+```go
+registry.AddSecurityScheme("bearerAuth", api.BearerSecurity("JWT"))
+registry.AddSecurityScheme("basicAuth", api.BasicSecurity())
+registry.AddSecurityScheme("apiKeyAuth", api.APIKeySecurity("X-API-Key", "header"))
+```
+
+If a route references a security name that was not registered, the OpenAPI generator assumes an HTTP bearer JWT scheme by default.
+
+## Schema tags
+
+Schemas are inferred from Go structs with reflection. The generator understands `json` tags and a few OpenAPI-oriented tags:
+
+```go
+type CreateUserRequest struct {
+	Email string `json:"email" format:"email" example:"user@example.com" validate:"required"`
+	Name  string `json:"name,omitempty"`
+}
+```
+
+Supported tags:
+
+- `json:"name,omitempty"` controls property names and optional fields.
+- `description:"..."` sets the schema description.
+- `format:"email"` sets the OpenAPI format.
+- `example:"..."` sets an example value. JSON literals such as `3`, `true`, or `{"x":1}` are parsed.
+- `validate:"required"` marks a field as required even when it has `omitempty`.
+
+## External router adapter example
+
+Adapters for third-party routers should live outside this module. A minimal adapter only needs to translate `api.Router.Handle` to the chosen router and register metadata:
+
+```go
+type RouterAdapter struct {
+	registry *api.Registry
+	// router *yourRouter
+}
+
+func (adapter *RouterAdapter) Handle(method string, path string, handler http.HandlerFunc, opts ...api.RouteOption) {
+	if adapter.registry != nil {
+		adapter.registry.Register(method, path, opts...)
+	}
+
+	// Translate method, path, and handler to your router here.
+}
+```

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+)
+
+// OpenAPIHandler returns a handler that serves the registry as OpenAPI JSON.
+func OpenAPIHandler(registry *Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		if err := json.NewEncoder(w).Encode(GenerateOpenAPI(registry)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+// SwaggerUIHandler returns a handler that serves Swagger UI for an OpenAPI URL.
+func SwaggerUIHandler(openAPIURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, swaggerUIHTML, html.EscapeString(openAPIURL))
+	}
+}
+
+const swaggerUIHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>API Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    window.onload = function() {
+      window.ui = SwaggerUIBundle({
+        url: "%s",
+        dom_id: "#swagger-ui"
+      });
+    };
+  </script>
+</body>
+</html>`

--- a/openapi.go
+++ b/openapi.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// OpenAPI is the generated OpenAPI 3 document.
+type OpenAPI struct {
+	OpenAPI    string                          `json:"openapi"`
+	Info       Info                            `json:"info"`
+	Paths      map[string]map[string]Operation `json:"paths"`
+	Components *Components                     `json:"components,omitempty"`
+}
+
+// Components contains reusable OpenAPI components.
+type Components struct {
+	SecuritySchemes map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+}
+
+// SecurityScheme is an OpenAPI security scheme object.
+type SecurityScheme struct {
+	Type         string `json:"type"`
+	Scheme       string `json:"scheme,omitempty"`
+	BearerFormat string `json:"bearerFormat,omitempty"`
+	Name         string `json:"name,omitempty"`
+	In           string `json:"in,omitempty"`
+}
+
+// Operation is an OpenAPI operation object.
+type Operation struct {
+	Summary     string                    `json:"summary,omitempty"`
+	Description string                    `json:"description,omitempty"`
+	Tags        []string                  `json:"tags,omitempty"`
+	Parameters  []OpenAPIParameter        `json:"parameters,omitempty"`
+	RequestBody *RequestBodyObject        `json:"requestBody,omitempty"`
+	Responses   map[string]ResponseObject `json:"responses"`
+	Security    []map[string][]string     `json:"security,omitempty"`
+}
+
+// OpenAPIParameter is an OpenAPI parameter object.
+type OpenAPIParameter struct {
+	Name        string  `json:"name"`
+	In          string  `json:"in"`
+	Required    bool    `json:"required,omitempty"`
+	Description string  `json:"description,omitempty"`
+	Schema      *Schema `json:"schema,omitempty"`
+}
+
+// RequestBodyObject is an OpenAPI requestBody object.
+type RequestBodyObject struct {
+	Required bool                 `json:"required,omitempty"`
+	Content  map[string]MediaType `json:"content"`
+}
+
+// MediaType is an OpenAPI media type object.
+type MediaType struct {
+	Schema *Schema `json:"schema,omitempty"`
+}
+
+// ResponseObject is an OpenAPI response object.
+type ResponseObject struct {
+	Description string               `json:"description"`
+	Content     map[string]MediaType `json:"content,omitempty"`
+}
+
+// GenerateOpenAPI renders an OpenAPI 3.0 document from a registry.
+func GenerateOpenAPI(registry *Registry) OpenAPI {
+	doc := OpenAPI{
+		OpenAPI: "3.0.3",
+		Paths:   make(map[string]map[string]Operation),
+	}
+	if registry == nil {
+		return doc
+	}
+	doc.Info = registry.Info()
+	for name, scheme := range registry.SecuritySchemes() {
+		if doc.Components == nil {
+			doc.Components = &Components{SecuritySchemes: make(map[string]SecurityScheme)}
+		}
+		doc.Components.SecuritySchemes[name] = scheme
+	}
+	for _, route := range registry.Routes() {
+		path := normalizeOpenAPIPath(route.Path)
+		method := strings.ToLower(route.Method)
+		if doc.Paths[path] == nil {
+			doc.Paths[path] = make(map[string]Operation)
+		}
+		doc.Paths[path][method] = buildOperation(route)
+		for _, security := range route.Security {
+			if doc.Components == nil {
+				doc.Components = &Components{SecuritySchemes: make(map[string]SecurityScheme)}
+			}
+			if _, ok := doc.Components.SecuritySchemes[security]; !ok {
+				doc.Components.SecuritySchemes[security] = SecurityScheme{
+					Type:         "http",
+					Scheme:       "bearer",
+					BearerFormat: "JWT",
+				}
+			}
+		}
+	}
+	return doc
+}
+
+func buildOperation(route Route) Operation {
+	operation := Operation{
+		Summary:     route.Summary,
+		Description: route.Description,
+		Tags:        route.Tags,
+		Responses:   make(map[string]ResponseObject),
+	}
+	for _, param := range route.Parameters {
+		schema := param.Schema
+		if schema == nil {
+			schema = &Schema{Type: string(param.Type)}
+			if param.Type == Int {
+				schema.Format = "int32"
+			}
+		}
+		operation.Parameters = append(operation.Parameters, OpenAPIParameter{
+			Name:        param.Name,
+			In:          param.In,
+			Required:    param.Required || param.In == "path",
+			Description: param.Description,
+			Schema:      schema,
+		})
+	}
+	sort.Slice(operation.Parameters, func(i, j int) bool {
+		if operation.Parameters[i].In == operation.Parameters[j].In {
+			return operation.Parameters[i].Name < operation.Parameters[j].Name
+		}
+		return operation.Parameters[i].In < operation.Parameters[j].In
+	})
+	if route.Body != nil || route.BodySchema != nil {
+		schema := route.BodySchema
+		if schema == nil {
+			schema = SchemaFromType(route.Body)
+		}
+		operation.RequestBody = &RequestBodyObject{
+			Required: true,
+			Content: map[string]MediaType{
+				"application/json": {Schema: schema},
+			},
+		}
+	}
+	for _, response := range route.Responses {
+		description := response.Description
+		if description == "" {
+			description = http.StatusText(response.Status)
+		}
+		if description == "" {
+			description = "Response"
+		}
+		object := ResponseObject{Description: description}
+		schema := response.Schema
+		if schema == nil && response.Body != nil {
+			schema = SchemaFromType(response.Body)
+		}
+		if schema != nil {
+			object.Content = map[string]MediaType{
+				"application/json": {Schema: schema},
+			}
+		}
+		operation.Responses[strconv.Itoa(response.Status)] = object
+	}
+	if len(operation.Responses) == 0 {
+		operation.Responses["204"] = ResponseObject{Description: "No Content"}
+	}
+	for _, security := range route.Security {
+		operation.Security = append(operation.Security, map[string][]string{security: {}})
+	}
+	return operation
+}
+
+func normalizeOpenAPIPath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,316 @@
+package api
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Info contains the public API metadata rendered into OpenAPI.
+type Info struct {
+	Title       string `json:"title"`
+	Version     string `json:"version"`
+	Description string `json:"description,omitempty"`
+}
+
+// DataType describes primitive route parameter types.
+type DataType string
+
+const (
+	String DataType = "string"
+	Int    DataType = "integer"
+	Float  DataType = "number"
+	Bool   DataType = "boolean"
+)
+
+// Parameter describes a query, path, header, or cookie parameter.
+type Parameter struct {
+	Name        string
+	In          string
+	Type        DataType
+	Required    bool
+	Description string
+	Schema      *Schema
+}
+
+// Route describes a registered HTTP operation.
+type Route struct {
+	Method      string
+	Path        string
+	Summary     string
+	Description string
+	Tags        []string
+	Body        interface{}
+	BodySchema  *Schema
+	Responses   []RouteResponse
+	Parameters  []Parameter
+	Security    []string
+}
+
+// RouteResponse describes an HTTP response for an operation.
+type RouteResponse struct {
+	Status      int
+	Description string
+	Body        interface{}
+	Schema      *Schema
+}
+
+// Registry stores route metadata for OpenAPI generation.
+type Registry struct {
+	info            Info
+	mu              sync.RWMutex
+	routes          []Route
+	securitySchemes map[string]SecurityScheme
+}
+
+// NewRegistry creates a metadata registry.
+func NewRegistry(info Info) *Registry {
+	return &Registry{
+		info:            info,
+		securitySchemes: make(map[string]SecurityScheme),
+	}
+}
+
+// Info returns the registry API metadata.
+func (registry *Registry) Info() Info {
+	if registry == nil {
+		return Info{}
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	return registry.info
+}
+
+// Register stores a route and applies its declarative options.
+func (registry *Registry) Register(method string, path string, opts ...RouteOption) Route {
+	route := Route{
+		Method: method,
+		Path:   path,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&route)
+		}
+	}
+	if registry == nil {
+		return route
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.routes = append(registry.routes, cloneRoute(route))
+	return route
+}
+
+// Routes returns a snapshot of registered routes.
+func (registry *Registry) Routes() []Route {
+	if registry == nil {
+		return nil
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	routes := make([]Route, len(registry.routes))
+	for i := range registry.routes {
+		routes[i] = cloneRoute(registry.routes[i])
+	}
+	return routes
+}
+
+// AddSecurityScheme registers a reusable OpenAPI security scheme.
+func (registry *Registry) AddSecurityScheme(name string, scheme SecurityScheme) {
+	if registry == nil || name == "" {
+		return
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.securitySchemes[name] = scheme
+}
+
+// SecuritySchemes returns a snapshot of configured security schemes.
+func (registry *Registry) SecuritySchemes() map[string]SecurityScheme {
+	if registry == nil {
+		return nil
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	schemes := make(map[string]SecurityScheme, len(registry.securitySchemes))
+	for name, scheme := range registry.securitySchemes {
+		schemes[name] = scheme
+	}
+	return schemes
+}
+
+// BearerSecurity returns an HTTP bearer security scheme.
+func BearerSecurity(format string) SecurityScheme {
+	return SecurityScheme{Type: "http", Scheme: "bearer", BearerFormat: format}
+}
+
+// BasicSecurity returns an HTTP basic security scheme.
+func BasicSecurity() SecurityScheme {
+	return SecurityScheme{Type: "http", Scheme: "basic"}
+}
+
+// APIKeySecurity returns an API key security scheme.
+func APIKeySecurity(name string, in string) SecurityScheme {
+	return SecurityScheme{Type: "apiKey", Name: name, In: in}
+}
+
+// RouteOption mutates route metadata.
+type RouteOption func(*Route)
+
+// Summary sets the OpenAPI operation summary.
+func Summary(summary string) RouteOption {
+	return func(route *Route) {
+		route.Summary = summary
+	}
+}
+
+// Description sets the OpenAPI operation description.
+func Description(description string) RouteOption {
+	return func(route *Route) {
+		route.Description = description
+	}
+}
+
+// Tags sets the OpenAPI operation tags.
+func Tags(tags ...string) RouteOption {
+	return func(route *Route) {
+		route.Tags = append(route.Tags, tags...)
+	}
+}
+
+// Body sets the request body model inferred with reflection.
+func Body(body interface{}) RouteOption {
+	return func(route *Route) {
+		route.Body = body
+	}
+}
+
+// BodySchema sets a manual request body schema.
+func BodySchema(schema *Schema) RouteOption {
+	return func(route *Route) {
+		route.BodySchema = schema
+	}
+}
+
+// ResponseStatus adds a response model for a status code.
+//
+// The shorter name Response is already an exported interface in this package,
+// so this option keeps backward compatibility with the existing API.
+func ResponseStatus(status int, body interface{}) RouteOption {
+	return ResponseWithDescription(status, "", body)
+}
+
+// Status is a short alias for ResponseStatus.
+func Status(status int, body interface{}) RouteOption {
+	return ResponseStatus(status, body)
+}
+
+// Responds is a readable alias for ResponseStatus.
+func Responds(status int, body interface{}) RouteOption {
+	return ResponseStatus(status, body)
+}
+
+// ResponseWithDescription adds a response model and description.
+func ResponseWithDescription(status int, description string, body interface{}) RouteOption {
+	return func(route *Route) {
+		route.Responses = append(route.Responses, RouteResponse{
+			Status:      status,
+			Description: description,
+			Body:        body,
+		})
+	}
+}
+
+// ResponseSchema adds a response with a manual schema.
+func ResponseSchema(status int, description string, schema *Schema) RouteOption {
+	return func(route *Route) {
+		route.Responses = append(route.Responses, RouteResponse{
+			Status:      status,
+			Description: description,
+			Schema:      schema,
+		})
+	}
+}
+
+// Query adds a query parameter.
+func Query(name string, typ DataType, required bool) RouteOption {
+	return parameter("query", name, typ, required)
+}
+
+// Path adds a path parameter.
+func Path(name string, typ DataType, required bool) RouteOption {
+	return parameter("path", name, typ, required)
+}
+
+// Security adds a named security requirement to the operation.
+func Security(name string) RouteOption {
+	return func(route *Route) {
+		route.Security = append(route.Security, name)
+	}
+}
+
+func parameter(in string, name string, typ DataType, required bool) RouteOption {
+	return func(route *Route) {
+		route.Parameters = append(route.Parameters, Parameter{
+			Name:     name,
+			In:       in,
+			Type:     typ,
+			Required: required,
+		})
+	}
+}
+
+// ErrorResponse is a small reusable schema model for documented errors.
+type ErrorResponse struct {
+	Title   string `json:"title,omitempty"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
+type registryRouter struct {
+	registry *Registry
+}
+
+// NewMetadataRouter creates a router useful for tests and documentation-only registration.
+func NewMetadataRouter(registry *Registry) Router {
+	return registryRouter{registry: registry}
+}
+
+func (router registryRouter) Handle(method string, path string, handler http.HandlerFunc, opts ...RouteOption) {
+	if router.registry != nil {
+		router.registry.Register(method, path, opts...)
+	}
+}
+
+func cloneRoute(route Route) Route {
+	clone := route
+	clone.Tags = append([]string(nil), route.Tags...)
+	clone.Parameters = append([]Parameter(nil), route.Parameters...)
+	for i := range clone.Parameters {
+		clone.Parameters[i].Schema = cloneSchema(route.Parameters[i].Schema)
+	}
+	clone.Security = append([]string(nil), route.Security...)
+	clone.Responses = append([]RouteResponse(nil), route.Responses...)
+	for i := range clone.Responses {
+		clone.Responses[i].Schema = cloneSchema(route.Responses[i].Schema)
+	}
+	clone.BodySchema = cloneSchema(route.BodySchema)
+	return clone
+}
+
+func cloneSchema(schema *Schema) *Schema {
+	if schema == nil {
+		return nil
+	}
+	clone := *schema
+	if schema.Properties != nil {
+		clone.Properties = make(map[string]*Schema, len(schema.Properties))
+		for name, property := range schema.Properties {
+			clone.Properties[name] = cloneSchema(property)
+		}
+	}
+	clone.Items = cloneSchema(schema.Items)
+	clone.AdditionalProperties = cloneSchema(schema.AdditionalProperties)
+	clone.Required = append([]string(nil), schema.Required...)
+	clone.Enum = append([]interface{}(nil), schema.Enum...)
+	return &clone
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type createTaskRequest struct {
+	Title string `json:"title"`
+}
+
+type taskResponse struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+}
+
+func TestRegistryRegistersRoutesWithMetadata(t *testing.T) {
+	registry := NewRegistry(Info{Title: "Tasks API", Version: "1.0.0"})
+	router := NewMetadataRouter(registry)
+
+	Post(router, "/tasks", func(w http.ResponseWriter, r *http.Request) {},
+		Summary("Create task"),
+		Description("Creates a new task"),
+		Tags("tasks"),
+		Body(createTaskRequest{}),
+		ResponseStatus(http.StatusCreated, taskResponse{}),
+		Query("dry_run", Bool, false),
+		Security("bearerAuth"),
+	)
+
+	routes := registry.Routes()
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	route := routes[0]
+	if route.Method != http.MethodPost || route.Path != "/tasks" {
+		t.Fatalf("unexpected route: %#v", route)
+	}
+	if route.Summary != "Create task" || route.Description != "Creates a new task" {
+		t.Fatalf("metadata was not registered: %#v", route)
+	}
+	if len(route.Tags) != 1 || route.Tags[0] != "tasks" {
+		t.Fatalf("tags were not registered: %#v", route.Tags)
+	}
+	if len(route.Responses) != 1 || route.Responses[0].Status != http.StatusCreated {
+		t.Fatalf("responses were not registered: %#v", route.Responses)
+	}
+}
+
+func TestGenerateOpenAPI(t *testing.T) {
+	registry := NewRegistry(Info{Title: "Tasks API", Version: "1.0.0"})
+	registry.AddSecurityScheme("bearerAuth", BearerSecurity("JWT"))
+	registry.Register(http.MethodGet, "/tasks/{id}",
+		Summary("Get task"),
+		Tags("tasks"),
+		Path("id", Int, true),
+		Security("bearerAuth"),
+		ResponseStatus(http.StatusOK, taskResponse{}),
+		ResponseStatus(http.StatusBadRequest, ErrorResponse{}),
+	)
+
+	doc := GenerateOpenAPI(registry)
+	if doc.OpenAPI != "3.0.3" {
+		t.Fatalf("unexpected OpenAPI version: %s", doc.OpenAPI)
+	}
+	operation, ok := doc.Paths["/tasks/{id}"]["get"]
+	if !ok {
+		t.Fatalf("GET /tasks/{id} operation was not generated: %#v", doc.Paths)
+	}
+	if operation.Summary != "Get task" {
+		t.Fatalf("unexpected summary: %s", operation.Summary)
+	}
+	if len(operation.Parameters) != 1 || operation.Parameters[0].Name != "id" {
+		t.Fatalf("path parameter was not generated: %#v", operation.Parameters)
+	}
+	response := operation.Responses["200"]
+	if response.Content["application/json"].Schema.Properties["id"].Type != "integer" {
+		t.Fatalf("response schema was not generated: %#v", response)
+	}
+	if doc.Components.SecuritySchemes["bearerAuth"].Scheme != "bearer" {
+		t.Fatalf("security scheme was not generated: %#v", doc.Components)
+	}
+}
+
+func TestGenerateOpenAPIUsesConfiguredSecurityScheme(t *testing.T) {
+	registry := NewRegistry(Info{Title: "Tasks API", Version: "1.0.0"})
+	registry.AddSecurityScheme("apiKeyAuth", APIKeySecurity("X-API-Key", "header"))
+	registry.Register(http.MethodGet, "/tasks", Security("apiKeyAuth"), ResponseStatus(http.StatusOK, taskResponse{}))
+
+	doc := GenerateOpenAPI(registry)
+	scheme := doc.Components.SecuritySchemes["apiKeyAuth"]
+	if scheme.Type != "apiKey" || scheme.Name != "X-API-Key" || scheme.In != "header" {
+		t.Fatalf("configured security scheme was not used: %#v", scheme)
+	}
+}
+
+func TestRegistryRoutesReturnsDefensiveCopy(t *testing.T) {
+	registry := NewRegistry(Info{Title: "Tasks API", Version: "1.0.0"})
+	registry.Register(http.MethodGet, "/tasks",
+		Tags("tasks"),
+		ResponseSchema(http.StatusOK, "OK", &Schema{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"id": {Type: "integer"},
+			},
+		}),
+	)
+
+	routes := registry.Routes()
+	routes[0].Tags[0] = "mutated"
+	routes[0].Responses[0].Schema.Properties["id"].Type = "string"
+
+	fresh := registry.Routes()
+	if fresh[0].Tags[0] != "tasks" {
+		t.Fatalf("tags were mutated through Routes snapshot: %#v", fresh[0].Tags)
+	}
+	if fresh[0].Responses[0].Schema.Properties["id"].Type != "integer" {
+		t.Fatalf("schema was mutated through Routes snapshot: %#v", fresh[0].Responses[0].Schema)
+	}
+}
+
+func TestOpenAPIHandler(t *testing.T) {
+	registry := NewRegistry(Info{Title: "Tasks API", Version: "1.0.0"})
+	registry.Register(http.MethodGet, "/tasks", ResponseStatus(http.StatusOK, []taskResponse{}))
+
+	req := httptest.NewRequest(http.MethodGet, "/openapi.json", nil)
+	res := httptest.NewRecorder()
+	OpenAPIHandler(registry).ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", res.Code)
+	}
+	var doc OpenAPI
+	if err := json.Unmarshal(res.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("handler returned invalid JSON: %v", err)
+	}
+	if doc.Info.Title != "Tasks API" {
+		t.Fatalf("unexpected info: %#v", doc.Info)
+	}
+}
+
+func TestGenerateOpenAPIMinimalDocumentShape(t *testing.T) {
+	type createUserRequest struct {
+		Email string `json:"email" format:"email" example:"user@example.com" validate:"required"`
+		Name  string `json:"name,omitempty"`
+	}
+	type userResponse struct {
+		ID    int    `json:"id"`
+		Email string `json:"email" format:"email"`
+	}
+
+	registry := NewRegistry(Info{
+		Title:       "Users API",
+		Version:     "1.0.0",
+		Description: "User management API",
+	})
+	registry.AddSecurityScheme("apiKeyAuth", APIKeySecurity("X-API-Key", "header"))
+	registry.Register(http.MethodPost, "/users",
+		Summary("Create user"),
+		Description("Creates a new user"),
+		Tags("users"),
+		Query("notify", Bool, false),
+		Security("apiKeyAuth"),
+		Body(createUserRequest{}),
+		ResponseStatus(http.StatusCreated, userResponse{}),
+	)
+
+	doc := GenerateOpenAPI(registry)
+	if doc.OpenAPI != "3.0.3" || doc.Info.Title != "Users API" || doc.Info.Description == "" {
+		t.Fatalf("unexpected document metadata: %#v", doc)
+	}
+	operation := doc.Paths["/users"]["post"]
+	if operation.Summary != "Create user" || len(operation.Tags) != 1 || operation.Tags[0] != "users" {
+		t.Fatalf("unexpected operation metadata: %#v", operation)
+	}
+	if len(operation.Parameters) != 1 || operation.Parameters[0].Name != "notify" || operation.Parameters[0].Schema.Type != "boolean" {
+		t.Fatalf("unexpected query parameter: %#v", operation.Parameters)
+	}
+	emailRequestSchema := operation.RequestBody.Content["application/json"].Schema.Properties["email"]
+	if emailRequestSchema.Format != "email" || emailRequestSchema.Example != "user@example.com" {
+		t.Fatalf("request schema tags were not generated: %#v", emailRequestSchema)
+	}
+	if !containsString(operation.RequestBody.Content["application/json"].Schema.Required, "email") {
+		t.Fatalf("required field was not generated: %#v", operation.RequestBody.Content["application/json"].Schema.Required)
+	}
+	created := operation.Responses["201"]
+	if created.Description != "Created" || created.Content["application/json"].Schema.Properties["id"].Type != "integer" {
+		t.Fatalf("unexpected response schema: %#v", created)
+	}
+	if operation.Security[0]["apiKeyAuth"] == nil {
+		t.Fatalf("operation security was not generated: %#v", operation.Security)
+	}
+	scheme := doc.Components.SecuritySchemes["apiKeyAuth"]
+	if scheme.Type != "apiKey" || scheme.Name != "X-API-Key" || scheme.In != "header" {
+		t.Fatalf("security scheme was not generated: %#v", scheme)
+	}
+}

--- a/request_validator.go
+++ b/request_validator.go
@@ -14,6 +14,8 @@ type RequestContextKey string
 // RequestDataContextKey request data context key to finds request context
 const RequestDataContextKey = RequestContextKey("requestData")
 
+const routeVarsContextKey = RequestContextKey("routeVars")
+
 // RequestReceiver implementation of core.APIRequestReceiver interface
 type RequestReceiver struct{}
 
@@ -76,7 +78,19 @@ func (receiver RequestReceiver) GetRouteVar(key string, r *http.Request) string 
 
 // GetRouteVar returns the route variables for the current request, if any
 // define it as: api.GetRouteVar = myCustomGetRouteVarFunc
-var GetRouteVar func(string, *http.Request) string = func(string, *http.Request) string {
-	PrintError("Define a GetRouteVar function in this package")
-	return ""
+var GetRouteVar func(string, *http.Request) string = func(key string, r *http.Request) string {
+	return getRouteVarFromContext(key, r)
+}
+
+func getRouteVarFromContext(key string, r *http.Request) string {
+	vars, ok := r.Context().Value(routeVarsContextKey).(map[string]string)
+	if !ok {
+		return ""
+	}
+	return vars[key]
+}
+
+// SetRouteVars stores route variables in the request context.
+func SetRouteVars(vars map[string]string, r *http.Request) *http.Request {
+	return SetContextValue(routeVarsContextKey, vars, r)
 }

--- a/router.go
+++ b/router.go
@@ -1,0 +1,33 @@
+package api
+
+import "net/http"
+
+// Router is the minimal contract implemented by router adapters.
+type Router interface {
+	Handle(method string, path string, handler http.HandlerFunc, opts ...RouteOption)
+}
+
+// Get registers a GET route in a router adapter.
+func Get(router Router, path string, handler http.HandlerFunc, opts ...RouteOption) {
+	router.Handle(http.MethodGet, path, handler, opts...)
+}
+
+// Post registers a POST route in a router adapter.
+func Post(router Router, path string, handler http.HandlerFunc, opts ...RouteOption) {
+	router.Handle(http.MethodPost, path, handler, opts...)
+}
+
+// Put registers a PUT route in a router adapter.
+func Put(router Router, path string, handler http.HandlerFunc, opts ...RouteOption) {
+	router.Handle(http.MethodPut, path, handler, opts...)
+}
+
+// Patch registers a PATCH route in a router adapter.
+func Patch(router Router, path string, handler http.HandlerFunc, opts ...RouteOption) {
+	router.Handle(http.MethodPatch, path, handler, opts...)
+}
+
+// Delete registers a DELETE route in a router adapter.
+func Delete(router Router, path string, handler http.HandlerFunc, opts ...RouteOption) {
+	router.Handle(http.MethodDelete, path, handler, opts...)
+}

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// Schema is a small OpenAPI schema object.
+type Schema struct {
+	Type                 string             `json:"type,omitempty"`
+	Format               string             `json:"format,omitempty"`
+	Properties           map[string]*Schema `json:"properties,omitempty"`
+	Items                *Schema            `json:"items,omitempty"`
+	AdditionalProperties *Schema            `json:"additionalProperties,omitempty"`
+	Required             []string           `json:"required,omitempty"`
+	Description          string             `json:"description,omitempty"`
+	Enum                 []interface{}      `json:"enum,omitempty"`
+	Nullable             bool               `json:"nullable,omitempty"`
+	Ref                  string             `json:"$ref,omitempty"`
+	Example              interface{}        `json:"example,omitempty"`
+}
+
+// SchemaFromType infers an OpenAPI schema from a Go value or reflect.Type.
+func SchemaFromType(value interface{}) *Schema {
+	if schema, ok := value.(*Schema); ok {
+		return schema
+	}
+	if value == nil {
+		return &Schema{}
+	}
+	if typ, ok := value.(reflect.Type); ok {
+		return schemaFromReflectType(typ, make(map[reflect.Type]bool))
+	}
+	return schemaFromReflectType(reflect.TypeOf(value), make(map[reflect.Type]bool))
+}
+
+func schemaFromReflectType(typ reflect.Type, seen map[reflect.Type]bool) *Schema {
+	if typ == nil {
+		return &Schema{}
+	}
+	if typ == reflect.TypeOf(time.Time{}) {
+		return &Schema{Type: "string", Format: "date-time"}
+	}
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		schema := schemaFromReflectType(typ, seen)
+		schema.Nullable = true
+		return schema
+	}
+	switch typ.Kind() {
+	case reflect.Bool:
+		return &Schema{Type: "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return &Schema{Type: "integer", Format: "int32"}
+	case reflect.Int64:
+		return &Schema{Type: "integer", Format: "int64"}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return &Schema{Type: "integer", Format: "int32"}
+	case reflect.Uint64:
+		return &Schema{Type: "integer", Format: "int64"}
+	case reflect.Float32:
+		return &Schema{Type: "number", Format: "float"}
+	case reflect.Float64:
+		return &Schema{Type: "number", Format: "double"}
+	case reflect.String:
+		return &Schema{Type: "string"}
+	case reflect.Slice, reflect.Array:
+		return &Schema{Type: "array", Items: schemaFromReflectType(typ.Elem(), seen)}
+	case reflect.Map:
+		schema := &Schema{Type: "object"}
+		if typ.Key().Kind() == reflect.String {
+			schema.AdditionalProperties = schemaFromReflectType(typ.Elem(), seen)
+		}
+		return schema
+	case reflect.Struct:
+		return structSchema(typ, seen)
+	case reflect.Interface:
+		return &Schema{}
+	default:
+		return &Schema{Type: "string"}
+	}
+}
+
+func structSchema(typ reflect.Type, seen map[reflect.Type]bool) *Schema {
+	if seen[typ] {
+		return &Schema{Type: "object"}
+	}
+	seen[typ] = true
+	defer delete(seen, typ)
+
+	schema := &Schema{
+		Type:       "object",
+		Properties: make(map[string]*Schema),
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
+		name, omitEmpty, skip := jsonFieldName(field)
+		if skip {
+			continue
+		}
+		if field.Anonymous && name == "" {
+			embedded := schemaFromReflectType(field.Type, seen)
+			for propName, propSchema := range embedded.Properties {
+				schema.Properties[propName] = propSchema
+			}
+			schema.Required = append(schema.Required, embedded.Required...)
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		fieldSchema := schemaFromReflectType(field.Type, seen)
+		applySchemaTags(fieldSchema, field)
+		schema.Properties[name] = fieldSchema
+		if isRequiredField(field, omitEmpty) {
+			schema.Required = append(schema.Required, name)
+		}
+	}
+	if len(schema.Properties) == 0 {
+		schema.Properties = nil
+	}
+	if len(schema.Required) == 0 {
+		schema.Required = nil
+	}
+	return schema
+}
+
+func jsonFieldName(field reflect.StructField) (string, bool, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", false, true
+	}
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	omitEmpty := false
+	for _, part := range parts[1:] {
+		if part == "omitempty" {
+			omitEmpty = true
+		}
+	}
+	return name, omitEmpty, false
+}
+
+func applySchemaTags(schema *Schema, field reflect.StructField) {
+	if description := field.Tag.Get("description"); description != "" {
+		schema.Description = description
+	}
+	if format := field.Tag.Get("format"); format != "" {
+		schema.Format = format
+	}
+	if example := field.Tag.Get("example"); example != "" {
+		schema.Example = parseExample(example)
+	}
+}
+
+func parseExample(value string) interface{} {
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(value), &parsed); err == nil {
+		return parsed
+	}
+	return value
+}
+
+func isRequiredField(field reflect.StructField, omitEmpty bool) bool {
+	if hasValidateRule(field.Tag.Get("validate"), "required") {
+		return true
+	}
+	return !omitEmpty && !isNullable(field.Type)
+}
+
+func hasValidateRule(tag string, rule string) bool {
+	for _, part := range strings.Split(tag, ",") {
+		name := strings.SplitN(part, "=", 2)[0]
+		if name == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func isNullable(typ reflect.Type) bool {
+	switch typ.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Interface:
+		return true
+	default:
+		return false
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+type schemaAddress struct {
+	City string `json:"city"`
+}
+
+type schemaExample struct {
+	ID        int               `json:"id"`
+	Name      string            `json:"name,omitempty"`
+	Email     string            `json:"email,omitempty" format:"email" example:"user@example.com" validate:"required"`
+	Count     int               `json:"count,omitempty" example:"3"`
+	CreatedAt time.Time         `json:"created_at"`
+	Address   *schemaAddress    `json:"address,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Ignored   string            `json:"-"`
+}
+
+func TestSchemaFromTypeSupportsCommonGoShapes(t *testing.T) {
+	schema := SchemaFromType(schemaExample{})
+
+	if schema.Type != "object" {
+		t.Fatalf("expected object schema, got %s", schema.Type)
+	}
+	if schema.Properties["id"].Type != "integer" {
+		t.Fatalf("expected integer id schema: %#v", schema.Properties["id"])
+	}
+	if schema.Properties["created_at"].Format != "date-time" {
+		t.Fatalf("expected time.Time date-time schema: %#v", schema.Properties["created_at"])
+	}
+	if schema.Properties["email"].Format != "email" || schema.Properties["email"].Example != "user@example.com" {
+		t.Fatalf("expected format and example tags in email schema: %#v", schema.Properties["email"])
+	}
+	if schema.Properties["count"].Example != float64(3) {
+		t.Fatalf("expected numeric example tag in count schema: %#v", schema.Properties["count"])
+	}
+	if schema.Properties["address"].Nullable != true {
+		t.Fatalf("expected pointer schema to be nullable: %#v", schema.Properties["address"])
+	}
+	if schema.Properties["address"].Properties["city"].Type != "string" {
+		t.Fatalf("expected nested struct schema: %#v", schema.Properties["address"])
+	}
+	if schema.Properties["tags"].Items.Type != "string" {
+		t.Fatalf("expected slice item schema: %#v", schema.Properties["tags"])
+	}
+	if schema.Properties["metadata"].AdditionalProperties.Type != "string" {
+		t.Fatalf("expected map value schema: %#v", schema.Properties["metadata"])
+	}
+	if _, ok := schema.Properties["Ignored"]; ok {
+		t.Fatalf("json:- field should not be included")
+	}
+	if !containsString(schema.Required, "email") {
+		t.Fatalf("expected validate required field in required list, got %#v", schema.Required)
+	}
+	if len(schema.Required) != 3 {
+		t.Fatalf("expected non-omitempty fields plus validate required, got %#v", schema.Required)
+	}
+}
+
+func TestSchemaFromTypeAllowsManualSchema(t *testing.T) {
+	manual := &Schema{Type: "string", Format: "uuid"}
+	if got := SchemaFromType(manual); got != manual {
+		t.Fatalf("manual schema should be returned as-is")
+	}
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/stdadapter/stdadapter.go
+++ b/stdadapter/stdadapter.go
@@ -1,0 +1,165 @@
+package stdadapter
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/jgolang/api"
+)
+
+type route struct {
+	method  string
+	path    string
+	handler http.HandlerFunc
+}
+
+// Router adapts http.ServeMux to api.Router.
+type Router struct {
+	mux      *http.ServeMux
+	registry *api.Registry
+	mu       sync.Mutex
+	routes   map[string][]route
+	handled  map[string]bool
+}
+
+// New creates a net/http adapter.
+func New(mux *http.ServeMux, registry *api.Registry) *Router {
+	if mux == nil {
+		mux = http.NewServeMux()
+	}
+	return &Router{
+		mux:      mux,
+		registry: registry,
+		routes:   make(map[string][]route),
+		handled:  make(map[string]bool),
+	}
+}
+
+// ServeHTTP delegates to the wrapped ServeMux.
+func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	router.mux.ServeHTTP(w, r)
+}
+
+// Handle registers an HTTP handler and stores its metadata.
+func (router *Router) Handle(method string, path string, handler http.HandlerFunc, opts ...api.RouteOption) {
+	if router.registry != nil {
+		router.registry.Register(method, path, opts...)
+	}
+	pattern := serveMuxPattern(path)
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.routes[pattern] = append(router.routes[pattern], route{
+		method:  method,
+		path:    normalizePath(path),
+		handler: handler,
+	})
+	sort.SliceStable(router.routes[pattern], func(i, j int) bool {
+		return routePriority(router.routes[pattern][i].path) > routePriority(router.routes[pattern][j].path)
+	})
+	if router.handled[pattern] {
+		return
+	}
+	router.handled[pattern] = true
+	router.mux.HandleFunc(pattern, router.dispatch(pattern))
+}
+
+func (router *Router) dispatch(pattern string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		router.mu.Lock()
+		routes := append([]route(nil), router.routes[pattern]...)
+		router.mu.Unlock()
+
+		methodAllowed := false
+		for _, registered := range routes {
+			vars, match := matchPath(registered.path, r.URL.Path)
+			if !match {
+				continue
+			}
+			if registered.method != r.Method {
+				methodAllowed = true
+				continue
+			}
+			if len(vars) > 0 {
+				r = api.SetRouteVars(vars, r)
+			}
+			registered.handler.ServeHTTP(w, r)
+			return
+		}
+		if methodAllowed {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+func normalizePath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+	return path
+}
+
+func serveMuxPattern(path string) string {
+	path = normalizePath(path)
+	index := strings.Index(path, "{")
+	if index < 0 {
+		return path
+	}
+	prefix := path[:index]
+	slash := strings.LastIndex(prefix, "/")
+	if slash <= 0 {
+		return "/"
+	}
+	return prefix[:slash+1]
+}
+
+func matchPath(pattern string, path string) (map[string]string, bool) {
+	pattern = normalizePath(pattern)
+	path = normalizePath(path)
+	patternParts := splitPath(pattern)
+	pathParts := splitPath(path)
+	if len(patternParts) != len(pathParts) {
+		return nil, false
+	}
+	vars := make(map[string]string)
+	for i := range patternParts {
+		part := patternParts[i]
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			if pathParts[i] == "" {
+				return nil, false
+			}
+			vars[strings.TrimSuffix(strings.TrimPrefix(part, "{"), "}")] = pathParts[i]
+			continue
+		}
+		if part != pathParts[i] {
+			return nil, false
+		}
+	}
+	return vars, true
+}
+
+func splitPath(path string) []string {
+	path = strings.Trim(normalizePath(path), "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+func routePriority(path string) int {
+	priority := 0
+	for _, part := range splitPath(path) {
+		priority += 10
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			continue
+		}
+		priority += 100
+	}
+	return priority
+}

--- a/stdadapter/stdadapter_test.go
+++ b/stdadapter/stdadapter_test.go
@@ -1,0 +1,88 @@
+package stdadapter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jgolang/api"
+)
+
+func TestRouterRegistersServeMuxRouteAndMetadata(t *testing.T) {
+	registry := api.NewRegistry(api.Info{Title: "Tasks API", Version: "1.0.0"})
+	router := New(http.NewServeMux(), registry)
+
+	api.Get(router, "/tasks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}, api.Summary("List tasks"))
+
+	req := httptest.NewRequest(http.MethodGet, "/tasks", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("expected status 202, got %d", res.Code)
+	}
+	routes := registry.Routes()
+	if len(routes) != 1 || routes[0].Summary != "List tasks" {
+		t.Fatalf("route metadata was not registered: %#v", routes)
+	}
+}
+
+func TestRouterAllowsMultipleMethodsForSamePath(t *testing.T) {
+	router := New(http.NewServeMux(), nil)
+	api.Get(router, "/tasks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	api.Post(router, "/tasks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/tasks", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", res.Code)
+	}
+}
+
+func TestRouterMatchesBracePathParameters(t *testing.T) {
+	router := New(http.NewServeMux(), nil)
+	api.Get(router, "/tasks/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id, response := api.GetRouteVarValueString("id", r)
+		if response != nil {
+			t.Fatalf("expected route var id, got response %#v", response)
+		}
+		if id != "42" {
+			t.Fatalf("expected route var 42, got %s", id)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/tasks/42", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", res.Code)
+	}
+}
+
+func TestRouterPrefersMoreSpecificRoutes(t *testing.T) {
+	router := New(http.NewServeMux(), nil)
+	api.Get(router, "/files/{name}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+	api.Get(router, "/files/static", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/files/static", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status 200 from static route, got %d", res.Code)
+	}
+}


### PR DESCRIPTION
This pull request introduces a router-agnostic OpenAPI 3 and Swagger UI documentation system to the package, focusing on keeping the core library free from third-party router dependencies and relying on Go's standard library. It provides a metadata registry and adapters for OpenAPI generation, along with handlers for serving OpenAPI JSON and Swagger UI. The changes include new documentation, examples, and a flexible registration mechanism for routes and security schemes.

**OpenAPI and Swagger UI integration:**

- Added `OpenAPIHandler` and `SwaggerUIHandler` functions in `handlers.go` to serve OpenAPI JSON and Swagger UI HTML for any router, using only the standard `net/http` package.
- Introduced a new OpenAPI document generator in `openapi.go`, which builds OpenAPI 3.0 documents from registered routes, parameters, responses, and security schemes.

**Router-agnostic registry and route metadata:**

- Created a `Registry` in `registry.go` to register route metadata, security schemes, and provide thread-safe access for OpenAPI generation. Includes route options for summary, tags, request/response schemas, and security.

**Documentation and usage examples:**

- Updated `README.md` with a section and code example demonstrating router-agnostic OpenAPI documentation, including how to register routes and serve documentation endpoints.
- Added `docs/openapi.md` with detailed documentation on route metadata options, security schemes, schema tags, and guidelines for creating adapters for third-party routers.