### PR TITLE
[FEAT] Add autodoc configuration

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -47,15 +47,16 @@ func main() {
 	api.Post(router, "/tasks", createTask,
 		api.Summary("Create task"),
 		api.Tags("tasks"),
-		api.Body(CreateTaskRequest{}),
+		api.Body(api.RequestDoc[CreateTaskRequest]()),
 		api.Security("bearerAuth"),
-		api.Status(201, TaskResponse{}),
+		api.Status(201, api.SuccessDoc[TaskResponse]()),
+		api.Status(400, api.ErrorDoc()),
 	)
 
 	api.Get(router, "/tasks", listTasks,
 		api.Summary("List tasks"),
 		api.Tags("tasks"),
-		api.Status(200, []TaskResponse{}),
+		api.Status(200, api.SuccessDoc[[]TaskResponse]()),
 	)
 
 	router.Handle("GET", "/openapi.json", api.OpenAPIHandler(registry))
@@ -66,6 +67,32 @@ func main() {
 ```
 
 `api.Status`, `api.Responds`, and `api.ResponseStatus` document responses. The longer `ResponseStatus` name is kept because this package already has an exported `api.Response` interface.
+
+## Request and response wrappers
+
+Runtime requests use `api.JSONRequest`, whose `content` field is `json.RawMessage` for backward compatibility. For OpenAPI documentation, use typed wrappers so the generator can infer the payload schema:
+
+```go
+api.Body(api.JSONRequestOf[CreateTaskRequest]{})
+api.Body(api.RequestDoc[CreateTaskRequest]())
+```
+
+Runtime responses use `api.JSONResponse`, whose `content` field is `interface{}` for backward compatibility. For OpenAPI documentation, use typed wrappers so the generator can infer the payload schema:
+
+```go
+api.Status(http.StatusOK, api.JSONResponseOf[TaskResponse]{})
+api.Status(http.StatusOK, api.JSONResponseOf[[]TaskResponse]{})
+api.Status(http.StatusBadRequest, api.JSONErrorResponse{})
+```
+
+The helpers below are equivalent and often read better in route declarations:
+
+```go
+api.Status(http.StatusOK, api.SuccessDoc[TaskResponse]())
+api.Status(http.StatusBadRequest, api.ErrorDoc())
+```
+
+These types are for documentation only. They do not change the runtime request or response format.
 
 ## Route metadata options
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -163,8 +163,9 @@ func TestGenerateOpenAPIMinimalDocumentShape(t *testing.T) {
 		Tags("users"),
 		Query("notify", Bool, false),
 		Security("apiKeyAuth"),
-		Body(createUserRequest{}),
-		ResponseStatus(http.StatusCreated, userResponse{}),
+		Body(JSONRequestOf[createUserRequest]{}),
+		ResponseStatus(http.StatusCreated, JSONResponseOf[userResponse]{}),
+		ResponseStatus(http.StatusBadRequest, JSONErrorResponse{}),
 	)
 
 	doc := GenerateOpenAPI(registry)
@@ -178,16 +179,27 @@ func TestGenerateOpenAPIMinimalDocumentShape(t *testing.T) {
 	if len(operation.Parameters) != 1 || operation.Parameters[0].Name != "notify" || operation.Parameters[0].Schema.Type != "boolean" {
 		t.Fatalf("unexpected query parameter: %#v", operation.Parameters)
 	}
-	emailRequestSchema := operation.RequestBody.Content["application/json"].Schema.Properties["email"]
+	requestSchema := operation.RequestBody.Content["application/json"].Schema
+	if requestSchema.Properties["header"] == nil {
+		t.Fatalf("request wrapper header was not generated: %#v", requestSchema)
+	}
+	emailRequestSchema := requestSchema.Properties["content"].Properties["email"]
 	if emailRequestSchema.Format != "email" || emailRequestSchema.Example != "user@example.com" {
 		t.Fatalf("request schema tags were not generated: %#v", emailRequestSchema)
 	}
-	if !containsString(operation.RequestBody.Content["application/json"].Schema.Required, "email") {
-		t.Fatalf("required field was not generated: %#v", operation.RequestBody.Content["application/json"].Schema.Required)
+	if !containsString(requestSchema.Properties["content"].Required, "email") {
+		t.Fatalf("required field was not generated: %#v", requestSchema.Properties["content"].Required)
 	}
 	created := operation.Responses["201"]
-	if created.Description != "Created" || created.Content["application/json"].Schema.Properties["id"].Type != "integer" {
+	createdSchema := created.Content["application/json"].Schema
+	if created.Description != "Created" || createdSchema.Properties["header"] == nil {
 		t.Fatalf("unexpected response schema: %#v", created)
+	}
+	if createdSchema.Properties["content"].Properties["id"].Type != "integer" {
+		t.Fatalf("typed response content schema was not generated: %#v", createdSchema.Properties["content"])
+	}
+	if operation.Responses["400"].Content["application/json"].Schema.Properties["content"] != nil {
+		t.Fatalf("error response schema should not include content: %#v", operation.Responses["400"])
 	}
 	if operation.Security[0]["apiKeyAuth"] == nil {
 		t.Fatalf("operation security was not generated: %#v", operation.Security)

--- a/request_structures.go
+++ b/request_structures.go
@@ -10,6 +10,20 @@ type JSONRequest struct {
 	Content json.RawMessage `json:"content,omitempty"`
 }
 
+// JSONRequestOf documents a JSONRequest with a concrete content payload type.
+//
+// It is intended for OpenAPI schema generation only. Runtime requests keep using
+// JSONRequest for backward compatibility.
+type JSONRequestOf[T any] struct {
+	Header  JSONRequestInfo `json:"header,omitempty"`
+	Content T               `json:"content,omitempty"`
+}
+
+// RequestDoc returns a typed request wrapper for OpenAPI documentation.
+func RequestDoc[T any]() JSONRequestOf[T] {
+	return JSONRequestOf[T]{}
+}
+
 // JSONRequestInfo request info section fields for encrypted requests.
 type JSONRequestInfo struct {
 	UUID            string `json:"uuid,omitempty"`

--- a/response_structures.go
+++ b/response_structures.go
@@ -10,6 +10,30 @@ type JSONResponse struct {
 	Content interface{}      `json:"content,omitempty"`
 }
 
+// JSONResponseOf documents a JSONResponse with a concrete content payload type.
+//
+// It is intended for OpenAPI schema generation only. Runtime responses keep using
+// JSONResponse for backward compatibility.
+type JSONResponseOf[T any] struct {
+	Header  JSONResponseInfo `json:"header,omitempty"`
+	Content T                `json:"content,omitempty"`
+}
+
+// JSONErrorResponse documents an error response without a content payload.
+type JSONErrorResponse struct {
+	Header JSONResponseInfo `json:"header,omitempty"`
+}
+
+// SuccessDoc returns a typed success response wrapper for OpenAPI documentation.
+func SuccessDoc[T any]() JSONResponseOf[T] {
+	return JSONResponseOf[T]{}
+}
+
+// ErrorDoc returns an error response wrapper for OpenAPI documentation.
+func ErrorDoc() JSONErrorResponse {
+	return JSONErrorResponse{}
+}
+
 // JSONResponseInfo response body info section
 type JSONResponseInfo struct {
 	Type    core.ResponseType `json:"type"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -69,6 +69,62 @@ func TestSchemaFromTypeAllowsManualSchema(t *testing.T) {
 	}
 }
 
+func TestSchemaFromTypeSupportsTypedJSONResponseContent(t *testing.T) {
+	schema := SchemaFromType(JSONResponseOf[taskResponse]{})
+
+	if schema.Properties["header"].Properties["type"].Type != "string" {
+		t.Fatalf("expected header schema, got %#v", schema.Properties["header"])
+	}
+	content := schema.Properties["content"]
+	if content.Type != "object" {
+		t.Fatalf("expected content object schema, got %#v", content)
+	}
+	if content.Properties["id"].Type != "integer" {
+		t.Fatalf("expected content id schema, got %#v", content.Properties["id"])
+	}
+	if content.Properties["title"].Type != "string" {
+		t.Fatalf("expected content title schema, got %#v", content.Properties["title"])
+	}
+}
+
+func TestSchemaFromTypeSupportsTypedJSONResponseSliceContent(t *testing.T) {
+	schema := SchemaFromType(JSONResponseOf[[]taskResponse]{})
+
+	content := schema.Properties["content"]
+	if content.Type != "array" {
+		t.Fatalf("expected content array schema, got %#v", content)
+	}
+	if content.Items.Properties["id"].Type != "integer" {
+		t.Fatalf("expected array item DTO schema, got %#v", content.Items)
+	}
+}
+
+func TestSchemaFromTypeSupportsJSONErrorResponse(t *testing.T) {
+	schema := SchemaFromType(JSONErrorResponse{})
+
+	if _, ok := schema.Properties["header"]; !ok {
+		t.Fatalf("expected header property in error response schema: %#v", schema)
+	}
+	if _, ok := schema.Properties["content"]; ok {
+		t.Fatalf("error response schema should not include content: %#v", schema)
+	}
+}
+
+func TestSchemaFromTypeSupportsTypedJSONRequestContent(t *testing.T) {
+	schema := SchemaFromType(JSONRequestOf[createTaskRequest]{})
+
+	if schema.Properties["header"].Properties["uuid"].Type != "string" {
+		t.Fatalf("expected request header schema, got %#v", schema.Properties["header"])
+	}
+	content := schema.Properties["content"]
+	if content.Type != "object" {
+		t.Fatalf("expected request content object schema, got %#v", content)
+	}
+	if content.Properties["title"].Type != "string" {
+		t.Fatalf("expected request content title schema, got %#v", content.Properties["title"])
+	}
+}
+
 func containsString(values []string, expected string) bool {
 	for _, value := range values {
 		if value == expected {


### PR DESCRIPTION
This pull request introduces new typed request and response wrappers to improve OpenAPI schema generation and documentation. These wrappers allow the OpenAPI generator to infer the payload schema for both requests and responses, without changing the runtime format. The changes update route and test declarations to use these wrappers, add helper functions for improved readability, and extend tests to verify the new schema generation.

**OpenAPI Documentation Improvements:**

* Added `JSONRequestOf[T]` and `JSONResponseOf[T]` generic types, along with `RequestDoc`, `SuccessDoc`, and `ErrorDoc` helpers, to allow OpenAPI documentation to infer the schema of request and response payloads (`request_structures.go`, `response_structures.go`). [[1]](diffhunk://#diff-b5942ae819964255af09de1955ebdfdb72495f70d5c6fa7e455b259786967effR13-R26) [[2]](diffhunk://#diff-ade4e8f561cb52bbfb3d11032e26f371b664f6f8e511a6ad84b8d59f47d4011fR13-R36)
* Updated documentation in `docs/openapi.md` to explain how to use the new wrappers and helpers in route declarations for better OpenAPI schema generation.

**Route and Test Declaration Updates:**

* Refactored route and test declarations to use the new typed wrappers and helpers for requests and responses, ensuring OpenAPI schemas are correctly generated (e.g., `api.Body(api.RequestDoc[CreateTaskRequest]())`, `api.Status(201, api.SuccessDoc[TaskResponse]())`). [[1]](diffhunk://#diff-d8052c2b0f17bd11ca86e9c21296d73792131498107f6de8cc90fd9189ee24d5L50-R59) [[2]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L166-R168)

**Testing Enhancements:**

* Extended tests to verify that OpenAPI schemas are generated correctly using the new wrappers, including validation of wrapped request/response content and error response schemas. [[1]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L181-R203) [[2]](diffhunk://#diff-b29dc7539ce1485f022d4257fc4ce1eb3143c3696bde9d34133eb7f80abc5b0fR72-R127)